### PR TITLE
Remove nil values from Arrthorizer::Repository

### DIFF
--- a/lib/arrthorizer/privilege.rb
+++ b/lib/arrthorizer/privilege.rb
@@ -13,7 +13,7 @@ module Arrthorizer
     end
 
     def self.get(name_or_privilege)
-      repository.get(name_or_privilege)
+      repository.fetch(name_or_privilege)
     end
 
     def make_accessible_to(role)
@@ -21,11 +21,11 @@ module Arrthorizer
     end
 
     def accessible_to?(role)
-      !!permitted_roles.get(role)
+      !!permitted_roles.fetch(role) { false }
     end
 
     def permitted_roles
-      @permitted_roles ||= Repository.new(raise_on_missing: false)
+      @permitted_roles ||= Repository.new
     end
 
     protected

--- a/lib/arrthorizer/repository.rb
+++ b/lib/arrthorizer/repository.rb
@@ -2,37 +2,23 @@ module Arrthorizer
   class Repository
     NotFound = Class.new(ArrthorizerException)
 
-    def initialize(options = {})
-      if options.fetch(:raise_on_missing) { true }
-        missing_handler = method(:raise_on_missing)
-      else
-        missing_handler = method(:safely_handle_missing)
-      end
-
-      @storage = Hash.new &missing_handler
+    def initialize
+      @storage = Hash.new
     end
 
     def add(privilege)
       storage[privilege.name] = privilege
     end
 
-    def get(key)
-      if key.respond_to? :name
-        storage[key.name]
-      else
-        storage[key]
-      end
+    def fetch(key, &block)
+      block ||= proc { raise NotFound, "Could not find value for #{key.inspect}" }
+
+      formatted_key = key.respond_to?(:name) ? key.name : key
+
+      @storage.fetch(formatted_key, &block)
     end
 
     private
     attr_reader :storage
-
-    def safely_handle_missing(hash, key)
-      nil
-    end
-
-    def raise_on_missing(hash, key)
-      raise NotFound, "Could not find value for #{key.inspect}"
-    end
   end
 end

--- a/lib/arrthorizer/role.rb
+++ b/lib/arrthorizer/role.rb
@@ -11,7 +11,7 @@ module Arrthorizer
       if name_or_role.respond_to?(:instance)
         get(name_or_role.instance)
       else
-        repository.get(name_or_role)
+        repository.fetch(name_or_role)
       end
     end
 

--- a/spec/integration/repository/missing_handler_spec.rb
+++ b/spec/integration/repository/missing_handler_spec.rb
@@ -1,24 +1,24 @@
 require "spec_helper"
 
 describe Arrthorizer::Repository do
-  subject(:repository) { Arrthorizer::Repository.new(raise_on_missing: raise_on_missing) }
+  subject(:repository) { Arrthorizer::Repository.new }
 
   context "when the requested value is not in the Repository" do
-    context "and the Repository was configured to raise on missing objects" do
-      let(:raise_on_missing) { true }
-
+    context "and no default value was specified" do
       it "raises an Arrthorizer::Repository::NotFound" do
         expect {
-          repository.get("some_value")
+          repository.fetch("some_value")
         }.to raise_error(Arrthorizer::Repository::NotFound)
       end
     end
 
-    context "and the Repository was configured to safely handle missing objects" do
-      subject(:repository) { Arrthorizer::Repository.new(raise_on_missing: false) }
+    context "and a default value was specified" do
+      subject(:repository) { Arrthorizer::Repository.new }
+      let(:default) { :default }
 
-      it "simply returns nil" do
-        expect(repository.get("some_value")).to be_nil
+      it "returns the default" do
+        actual = repository.fetch("some_value") { default }
+        expect(actual).to eq(default)
       end
     end
   end


### PR DESCRIPTION
Just an experiment: Don't use nil values when the value can't be found but make it behave like Hash#fetch, so we can specify behavior for missing values when applicable instead of at constuction time.
